### PR TITLE
Fixed Julia 0.6 deprecations

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
-julia 0.4
+julia 0.6
 Polynomials
 Compat 0.8.4

--- a/src/CurveFit.jl
+++ b/src/CurveFit.jl
@@ -43,10 +43,10 @@ export Poly
 
 # package code goes here
 "Abstract base class for fitting data"
-abstract ApproxFit
+abstract type ApproxFit end
 
 "Abstract class for least squares fitting of data"
-abstract LeastSquares <: ApproxFit
+abstract type LeastSquares <: ApproxFit end
 
 
 include("linfit.jl")
@@ -69,6 +69,6 @@ fit = curve_fit(LinearFit, x, y)
 y1 = fit(5.1)
 y2 = apply_fit(fit, 5.1)
 """
-apply_fit{T<:LeastSquares}(f::T, x) = f(x)
+apply_fit(f::T, x) where {T<:LeastSquares} = f(x)
 
 end # module

--- a/src/king.jl
+++ b/src/king.jl
@@ -9,16 +9,16 @@ The law is given by:
 
 This function estimates `A` and `B`.
 """
-linear_king_fit(E, U) = linear_fit(sqrt(U), E .* E)
+linear_king_fit(E, U) = linear_fit(sqrt.(U), E .* E)
 
 "Type that represents a Linear (original) King's law"
-immutable LinearKingFit <: LeastSquares
+struct LinearKingFit <: LeastSquares
     coefs::Array{Float64,1}
     LinearKingFit(coefs) = new(copy(coefs))
 end
 LinearKingFit(E,U) = LinearKingFit(linear_king_fit(E, U))
 
-@compat (f::LinearKingFit)(E) = ( (E.*E .- f.coefs[1]) ./ f.coefs[2] ) .^ 2
+(f::LinearKingFit)(E) = ( (E.*E .- f.coefs[1]) ./ f.coefs[2] ) .^ 2
 
 
 "Equation that computes the error of the modified King's law "
@@ -44,13 +44,13 @@ end
 
 
 "Type that represents the modified King's law "
-immutable KingFit <: LeastSquares
+struct KingFit <: LeastSquares
     coefs::Array{Float64,1}
     KingFit(coefs) = new(copy(coefs))
 end
 KingFit(E,U, eps=1e-8, maxiter=200) = KingFit(king_fit(E, U, eps, maxiter))
 
-@compat (f::KingFit)(E) = ( (E.*E .- f.coefs[1]) ./ f.coefs[2]) .^ (1./f.coefs[3])
+(f::KingFit)(E) = ( (E.*E .- f.coefs[1]) ./ f.coefs[2]) .^ (1./f.coefs[3])
 
 
 

--- a/src/linfit.jl
+++ b/src/linfit.jl
@@ -6,17 +6,17 @@
 linear_fit(x, y) = hcat(ones(x), x) \ y
 
 "Fits a log function through a set of points: `y = a₁+ a₂*log(x)`"
-log_fit(x, y) = linear_fit(log(x), y)
+log_fit(x, y) = linear_fit(log.(x), y)
 
 "Fits a power law through a set of points: `y = a₁*x^a₂`"
 function power_fit(x, y)
-    fit = linear_fit(log(x), log(y))
+    fit = linear_fit(log.(x), log.(y))
     [exp(fit[1]), fit[2]]
 end
 
 "Fits an `exp` through a set of points: `y = a₁*exp(a₂*x)`"
 function exp_fit(x, y)
-    fit = linear_fit(x, log(y))
+    fit = linear_fit(x, log.(y))
     [exp(fit[1]), fit[2]]
 end
 
@@ -49,33 +49,33 @@ end
 """
 High Level interface for fitting straight lines
 """
-immutable LinearFit{T<:Number} <: LeastSquares
+struct LinearFit{T<:Number} <: LeastSquares
     coefs::Array{T,1}
-    LinearFit(coefs) = new(copy(coefs))
+    LinearFit{T}(coefs) where {T<:Number} = new(copy(coefs))
 end
-LinearFit{T<:Number}(x::AbstractVector{T}, y::AbstractVector{T}) = LinearFit{T}(linear_fit(x, y))
+LinearFit(x::AbstractVector{T}, y::AbstractVector{T}) where {T<:Number} = LinearFit{T}(linear_fit(x, y))
 
 
 "High Level interface for fitting log laws"
-immutable LogFit{T<:Number} <: LeastSquares
+struct LogFit{T<:Number} <: LeastSquares
     coefs::Array{T,1}
-    LogFit(coefs) = new(copy(coefs))
+    LogFit{T}(coefs) where {T<:Number} = new(copy(coefs))
 end
-LogFit{T<:Number}(x::AbstractVector{T}, y::AbstractVector{T}) = LogFit{T}(log_fit(x, y))
+LogFit(x::AbstractVector{T}, y::AbstractVector{T}) where {T<:Number} = LogFit{T}(log_fit(x, y))
 
 "High Level interface for fitting power laws"
-immutable PowerFit{T<:Number} <: LeastSquares
+struct PowerFit{T<:Number} <: LeastSquares
     coefs::Array{T,1}
-    PowerFit(coefs) = new(copy(coefs))
+    PowerFit{T}(coefs) where {T<:Number} = new(copy(coefs))
 end
-PowerFit{T<:Number}(x::AbstractVector{T}, y::AbstractVector{T}) = PowerFit{T}(power_fit(x, y))
+PowerFit(x::AbstractVector{T}, y::AbstractVector{T}) where {T<:Number} = PowerFit{T}(power_fit(x, y))
 
 "High Level interface for fitting exp laws"
-immutable ExpFit{T<:Number} <: LeastSquares
+struct ExpFit{T<:Number} <: LeastSquares
     coefs::Array{T,1}
-    ExpFit(coefs) = new(copy(coefs))
+    ExpFit{T}(coefs) where {T<:Number} = new(copy(coefs))
 end
-ExpFit{T<:Number}(x::AbstractVector{T}, y::AbstractVector{T}) = ExpFit{T}(exp_fit(x, y))
+ExpFit(x::AbstractVector{T}, y::AbstractVector{T}) where {T<:Number} = ExpFit{T}(exp_fit(x, y))
 
 
 
@@ -91,18 +91,13 @@ can be used to estimate the value of the fitting model using function `apply_fit
  * `f = curve_fit(LinearFit, x, y)`
  * `f = curve_fit(Poly, x, y, n)`
 """
-curve_fit{T<:LeastSquares}(::Type{T}, x, y) = T(x, y)
-curve_fit{T<:LeastSquares}(::Type{T}, x, y, args...) = T(x, y, args...)
+curve_fit(::Type{T}, x, y) where {T<:LeastSquares} = T(x, y)
+curve_fit(::Type{T}, x, y, args...) where {T<:LeastSquares} = T(x, y, args...)
 curve_fit(::Type{Poly}, x, y, n=1) = Poly(poly_fit(x, y, n))
 
 
-import Base.call
 
-@compat (f::LinearFit)(x) = f.coefs[1] .+ f.coefs[2].*x
-@compat (f::PowerFit)(x) = f.coefs[1] .* x .^ f.coefs[2]
-@compat (f::LogFit)(x) = f.coefs[1] .+ f.coefs[2] .* log(x)
-@compat (f::ExpFit)(x) = f.coefs[1] .* exp(f.coefs[2] .* x)
-
-
-
-
+(f::LinearFit)(x) = f.coefs[1] .+ f.coefs[2].*x
+(f::PowerFit)(x) = f.coefs[1] .* x .^ f.coefs[2]
+(f::LogFit)(x) = f.coefs[1] .+ f.coefs[2] .* log(x)
+(f::ExpFit)(x) = f.coefs[1] .* exp(f.coefs[2] .* x)

--- a/src/nonlinfit.jl
+++ b/src/nonlinfit.jl
@@ -75,7 +75,7 @@ function nonlinear_fit(x, fun, a0, eps=1e-8, maxiter=200)
         r0[p] = fun(xp, a0)
         r1[p] = fun(xp, a1)
     end
-    maxerr = max(maxabs(r0), maxabs(r1))
+    maxerr = maximum(abs, [maximum(abs, r0), maximum(abs, r1)])
     iter = 1
     convergence = false
     for iter = 1:maxiter
@@ -103,7 +103,7 @@ function nonlinear_fit(x, fun, a0, eps=1e-8, maxiter=200)
             end
             r1[p] = fun(xp, a1)
         end
-        if maxabs(r1) < eps * maxerr
+        if maximum(abs, r1) < eps * maxerr
             convergence = true
             break
         end

--- a/src/rationalfit.jl
+++ b/src/rationalfit.jl
@@ -15,7 +15,7 @@ The linear case is solved by doing a least square fit on
 
 where the zero order term o `q(x)` is assumed to be 1.
 """
-function linear_rational_fit{T<:Number}(x::AbstractVector{T}, y::AbstractVector{T}, p, q)
+function linear_rational_fit(x::AbstractVector{T}, y::AbstractVector{T}, p, q) where T<:Number
     n = size(x,1)
     A = zeros(T, n, q+p+1)
     for i = 1:n
@@ -39,19 +39,19 @@ end
 A rational polynomial is the ratio of two polynomials
 and it is often useful in approximating functions.
 """
-immutable RationalPoly{T<:Number} <: LeastSquares
+struct RationalPoly{T<:Number} <: LeastSquares
     num::Poly{T}
     den::Poly{T}
 end
-RationalPoly{T<:Number}(a::AbstractVector{T}, b::AbstractVector{T}) = RationalPoly(Poly(a), Poly(b))
-RationalPoly{T<:Number}(p::Integer, q::Integer, ::Type{T}=Float64) = RationalPoly{T}(Poly(zeros(T,p+1)), Poly(zeros(T,q+1)))
-RationalPoly{T<:Number}(coefs::AbstractVector{T}, p, q) = RationalPoly(coefs[1:p+1],[1.0; coefs[p+2:end]])
+RationalPoly(a::AbstractVector{T}, b::AbstractVector{T}) where {T<:Number} = RationalPoly(Poly(a), Poly(b))
+RationalPoly(p::Integer, q::Integer, ::Type{T}=Float64) where {T<:Number} = RationalPoly{T}(Poly(zeros(T,p+1)), Poly(zeros(T,q+1)))
+RationalPoly(coefs::AbstractVector{T}, p, q) where {T<:Number} = RationalPoly(coefs[1:p+1],[1.0; coefs[p+2:end]])
 
 "Evaluate a rational polynomial"
-ratval{T<:Number}(r::RationalPoly{T}, x) = polyval(r.num, x) ./ polyval(r.den, x)
+ratval(r::RationalPoly{T}, x) where {T<:Number} = polyval(r.num, x) ./ polyval(r.den, x)
 
 "`call` overload for calling directly `ratval`"
-@compat (r::RationalPoly)(x) = ratval(r, x)
+(r::RationalPoly)(x) = ratval(r, x)
 
 "Auxiliary function used in nonlinear least squares"
 function make_rat_fun(p, q)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -11,81 +11,81 @@ fun0(x) = 1.0 + 2.0.*x
 y = fun0(x)
 f = linear_fit(x, y)
 
-@test_approx_eq_eps f[1] 1.0 1e-7
-@test_approx_eq_eps f[2] 2.0 1e-7
+@test f[1] ≈ 1.0 atol=1.0e-7
+@test f[2] ≈ 2.0 atol=1.0e-7
 
 f = curve_fit(LinearFit, x, y)
-@test_approx_eq_eps f(1.5) fun0(1.5) 1e-7
+@test f(1.5) ≈ fun0(1.5) atol=1.0e-7
 
 # power
-fun1(x) = 1.0 + 2.0*log(x)
+fun1(x) = 1.0 + 2.0*log.(x)
 y = fun1(x)
 f = log_fit(x, y)
-@test_approx_eq_eps f[1] 1.0 1e-7
-@test_approx_eq_eps f[2] 2.0 1e-7
+@test f[1] ≈ 1.0 atol=1.0e-7
+@test f[2] ≈ 2.0 atol=1.0e-7
 f = curve_fit(LogFit, x, y)
-@test_approx_eq_eps f(1.5) fun1(1.5) 1e-7
+@test f(1.5) ≈ fun1(1.5) atol=1.0e-7
 
 
 # log
 fun2(x) = 2.0*x.^0.8
 y = fun2(x)
 f = power_fit(x, y)
-@test_approx_eq_eps f[1] 2.0 1e-7
-@test_approx_eq_eps f[2] 0.8 1e-7
+@test f[1] ≈ 2.0 atol=1.0e-7
+@test f[2] ≈ 0.8 atol=1.0e-7
 f = curve_fit(PowerFit, x, y)
-@test_approx_eq_eps f(1.5) fun2(1.5) 1e-7
+@test f(1.5) ≈ fun2(1.5) atol=1.0e-7
 
 
 # Exp
-fun3(x) = 2.0*exp(0.8*x)
+fun3(x) = 2.0*exp.(0.8*x)
 y = fun3(x)
 f = exp_fit(x, y)
-@test_approx_eq_eps f[1] 2.0 1e-7
-@test_approx_eq_eps f[2] 0.8 1e-7
+@test f[1] ≈ 2.0 atol=1.0e-7
+@test f[2] ≈ 0.8 atol=1.0e-7
 f = curve_fit(ExpFit, x, y)
-@test_approx_eq_eps f(1.5) fun3(1.5) 1e-7
+@test f(1.5) ≈ fun3(1.5) atol=1.0e-7
 
 
 # Poly
 fun4(x) = 1.0 + 2.0*x + 3.0*x.^2 + 0.5*x.^3
 y = fun4(x)
 f = poly_fit(x, y, 4)
-@test_approx_eq_eps f[1] 1.0 1e-7
-@test_approx_eq_eps f[2] 2.0 1e-7
-@test_approx_eq_eps f[3] 3.0 1e-7
-@test_approx_eq_eps f[4] 0.5 1e-7
-@test_approx_eq_eps f[5] 0.0 1e-7
+@test f[1] ≈ 1.0 atol=1.0e-7
+@test f[2] ≈ 2.0 atol=1.0e-7
+@test f[3] ≈ 3.0 atol=1.0e-7
+@test f[4] ≈ 0.5 atol=1.0e-7
+@test f[5] ≈ 0.0 atol=1.0e-7
 
 f = curve_fit(Poly, x, y, 4)
-@test_approx_eq_eps f(1.5) fun4(1.5) 1e-7
+@test f(1.5) ≈ fun4(1.5) atol=1.0e-7
 
 # King's law
 U = [linspace(1, 20, 20);]
 A = 5.0
 B = 1.5
 n = 0.5
-E = sqrt(A + B*U.^n)
+E = sqrt.(A + B*U.^n)
 fun5(E) = ((E.^2 - A)/B).^(1./n)
 
 f = linear_king_fit(E, U)
-@test_approx_eq_eps f[1] A 1e-7
-@test_approx_eq_eps f[2] B 1e-7
+@test f[1] ≈ A atol=1.0e-7
+@test f[2] ≈ B atol=1.0e-7
 f= curve_fit(LinearKingFit, E, U)
-@test_approx_eq_eps f(3.0) fun5(3.0) 1e-7
+@test f(3.0) ≈ fun5(3.0) atol=1.0e-7
 
 # Modified King's law
 n = 0.42
 
-E = sqrt(A + B*U.^n)
+E = sqrt.(A + B*U.^n)
 fun6(E) = ((E.^2 - A)/B).^(1./n)
 
 f = king_fit(E, U)
-@test_approx_eq_eps f[1] A 1e-7
-@test_approx_eq_eps f[2] B 1e-7
-@test_approx_eq_eps f[3] n 1e-7
+@test f[1] ≈ A atol=1.0e-7
+@test f[2] ≈ B atol=1.0e-7
+@test f[3] ≈ n atol=1.0e-7
 f= curve_fit(KingFit, E, U)
-@test_approx_eq_eps f(3.0) fun6(3.0) 1e-5
+@test f(3.0) ≈ fun6(3.0) atol=1.0e-5
 
 
 
@@ -93,28 +93,28 @@ f= curve_fit(KingFit, E, U)
 r =  RationalPoly([1.0, 0.0, -2.0], [1.0, 2.0, 3.0])
 y = r(x)
 f = linear_rational_fit(x, y, 2, 3)
-@test_approx_eq_eps f[1] 1.0 1e-8
-@test_approx_eq_eps f[2] 0.0 1e-8
-@test_approx_eq_eps f[3] -2.0 1e-8
-@test_approx_eq_eps f[4] 2.0 1e-8
-@test_approx_eq_eps f[5] 3.0 1e-8
-@test_approx_eq_eps f[6] 0.0 1e-8
+@test f[1] ≈ 1.0 atol=1.0e-8
+@test f[2] ≈ 0.0 atol=1.0e-8
+@test f[3] ≈ -2.0 atol=1.0e-8
+@test f[4] ≈ 2.0 atol=1.0e-8
+@test f[5] ≈ 3.0 atol=1.0e-8
+@test f[6] ≈ 0.0 atol=1.0e-8
 
 # Nonlinear Rational fit
 f = rational_fit(x, y, 2, 3)
 
-@test_approx_eq_eps f[1] 1.0 1e-7
-@test_approx_eq_eps f[2] 0.0 1e-7
-@test_approx_eq_eps f[3] -2.0 1e-7
-@test_approx_eq_eps f[4] 2.0 1e-7
-@test_approx_eq_eps f[5] 3.0 1e-7
-@test_approx_eq_eps f[6] 0.0 1e-7
+@test f[1] ≈ 1.0 atol=1.0e-7
+@test f[2] ≈ 0.0 atol=1.0e-7
+@test f[3] ≈ -2.0 atol=1.0e-7
+@test f[4] ≈ 2.0 atol=1.0e-7
+@test f[5] ≈ 3.0 atol=1.0e-7
+@test f[6] ≈ 0.0 atol=1.0e-7
 
 
 
 f = curve_fit(RationalPoly, x, y, 2, 3)
-@test_approx_eq_eps f(1.5) r(1.5) 1e-8
-@test_approx_eq_eps f(4.5) r(4.5) 1e-8
+@test f(1.5) ≈ r(1.5) atol=1.0e-8
+@test f(4.5) ≈ r(4.5) atol=1.0e-8
 
 
 


### PR DESCRIPTION
Just updated the code a bit to fix the deprecation warnings that come up in Julia 0.6.0.

Haven't changed `.travis.yml`'s value for Julia to 0.6 since I don't know how it works or if anything else has to be changed to get it to work.