### PR TITLE
Allow integration with Unitful (only linear fit)

### DIFF
--- a/src/linfit.jl
+++ b/src/linfit.jl
@@ -10,8 +10,8 @@ function linear_fit(x, y)
 
     m = length(x)
 
-    sx2 = zero(sx)
-    sy2 = zero(sy)
+    sx2 = zero(sx.*sx)
+    sy2 = zero(sy.*sy)
     sxy = zero(sx*sy)
 
     for i = 1:m


### PR DESCRIPTION
Example:

```
using Unitful
using CurveFit

xs = collect(0:10) .* 1u"s"
ys = 3.14u"m/s" .* xs .+ 10u"m"
linear_fit(xs, ys)
```
