### PR TITLE
Update CI to only test supported Julia versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,9 @@
 name: CI
 on:
-  pull_request:
-    branches:
-      - master
   push:
-    branches:
-      - master
-    tags: '*'
+    branches: [master]
+    tags: ['*']
+  pull_request:
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
@@ -15,8 +12,8 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0'
-          - '1.5'
+          - '1.6'
+          - '1'
           - 'nightly'
         os:
           - ubuntu-latest
@@ -30,19 +27,10 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
+      - uses: julia-actions/cache@v1
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v2
         with:
           file: lcov.info

--- a/README.md
+++ b/README.md
@@ -1,11 +1,7 @@
 # CurveFit
 
 [![Build Status](https://github.com/pjabardo/CurveFit.jl/workflows/CI/badge.svg)](https://github.com/pjabardo/CurveFit.jl/actions)
-[![Build Status](https://travis-ci.com/pjabardo/CurveFit.jl.svg?branch=master)](https://travis-ci.com/pjabardo/CurveFit.jl)
-[![Build Status](https://ci.appveyor.com/api/projects/status/github/pjabardo/CurveFit.jl?svg=true)](https://ci.appveyor.com/project/pjabardo/CurveFit-jl)
 [![Coverage](https://codecov.io/gh/pjabardo/CurveFit.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/pjabardo/CurveFit.jl)
-[![Coverage](https://coveralls.io/repos/github/pjabardo/CurveFit.jl/badge.svg?branch=master)](https://coveralls.io/github/pjabardo/CurveFit.jl?branch=master)
-
 
 
 A package that implements a few curve fitting functions.
@@ -149,7 +145,3 @@ U2 = f2.(e)
 
 plot(U, E, "o", U1, e, "r-", U2, e, "g-", linewidth=3)
 ```
-
-
-
-[![Build Status](https://travis-ci.org/pjabardo/CurveFit.jl.svg)](https://travis-ci.org/pjabardo/CurveFit.jl)

--- a/src/expsumfit.jl
+++ b/src/expsumfit.jl
@@ -1,30 +1,30 @@
 using LinearAlgebra: diagm, qr!, eigvals
 
 struct ExpSumFit{T<:Real, S<:Number} <: AbstractLeastSquares
-	k::T          # constant
-	p::Vector{S}  # coefficients
-	λ::Vector{S}  # rate
-	τ::Vector{S}  # -1/rate
+    k::T          # constant
+    p::Vector{S}  # coefficients
+    λ::Vector{S}  # rate
+    τ::Vector{S}  # -1/rate
 end
 
 struct ExpSumFitInit{T<:Real}
-	n::Int                 # number of exponentials in the sum
-	m::Int                 # split integration intervals
-	Y::Matrix{T}           #
-	S::Matrix{T}           #
-	A::Vector{T}           #
-	Ā::Matrix{T}           # companion matrix
-	Xc::Matrix{Complex{T}} #
-	Xr::Matrix{T}          #
-	coeff::Matrix{T}       # numerical integration coefficients
+    n::Int                 # number of exponentials in the sum
+    m::Int                 # split integration intervals
+    Y::Matrix{T}           #
+    S::Matrix{T}           #
+    A::Vector{T}           #
+    Ā::Matrix{T}           # companion matrix
+    Xc::Matrix{Complex{T}} #
+    Xr::Matrix{T}          #
+    coeff::Matrix{T}       # numerical integration coefficients
 end
 
 """
-		expsum_fit(x::Union{T,AbstractVector{T}}, y::AbstractVector{T}, n::Int; m::Int = 1, withconst::Bool = true, init::Union{Nothing,ExpSumFitInit} = nothing) where {T <: Real}
+        expsum_fit(x::Union{T,AbstractVector{T}}, y::AbstractVector{T}, n::Int; m::Int = 1, withconst::Bool = true, init::Union{Nothing,ExpSumFitInit} = nothing) where {T <: Real}
 
 Fits the sum of `n` exponentials and a constant. 
 ```math
-	y = k + p_1 e^{\\lambda_1 t} + p_2 e^{\\lambda_2 t} + \\ldots + p_n e^{\\lambda_n t}
+    y = k + p_1 e^{\\lambda_1 t} + p_2 e^{\\lambda_2 t} + \\ldots + p_n e^{\\lambda_n t}
 ```
 If the keyword `withconst` is set to `false`, the constant is not fitted but set `k=0`.
 
@@ -39,110 +39,110 @@ The algorithm is from
 [Matlab code of Juan Gonzales Burgos](https://github.com/juangburgos/FitSumExponentials).
 """
 function expsum_fit(x::AbstractVector{T}, y::AbstractVector{T}, n::Int; m::Int = 1, withconst::Bool = true, init::Union{Nothing,ExpSumFitInit} = nothing) where {T <: Real}
-	n > 0 || throw(ArgumentError("number of exponent terms should be a positive integer"))
-	length(x) == length(y) || throw(DimensionMismatch("input vectors should be equal in length"))
-	m ≥ 2 && !all(isapprox.(diff(x), x[2] - x[1])) && error("m=$m requires uniformly spaced x")
-	if isnothing(init)
-		init = expsum_init(x, n, m = m, withconst = withconst)
-	else
-		(init.n == n && init.m == m && size(init.Xc)[1] == length(x)) || error("Init does not match parameters")
-	end
-	sc = expsum_scale!(x, y)
-	expfit_solve(init, x, y, sc)
+    n > 0 || throw(ArgumentError("number of exponent terms should be a positive integer"))
+    length(x) == length(y) || throw(DimensionMismatch("input vectors should be equal in length"))
+    m ≥ 2 && !all(isapprox.(diff(x), x[2] - x[1])) && error("m=$m requires uniformly spaced x")
+    if isnothing(init)
+        init = expsum_init(x, n, m = m, withconst = withconst)
+    else
+        (init.n == n && init.m == m && size(init.Xc)[1] == length(x)) || error("Init does not match parameters")
+    end
+    sc = expsum_scale!(x, y)
+    expfit_solve(init, x, y, sc)
 end
 
 function expsum_fit(dx::T, y::AbstractVector{T}, n::Int; kwargs...) where {T <: Real}
-	x = collect(range(0, step = dx, length = length(y)))
-	expsum_fit(x, y, n; kwargs...)
+    x = collect(range(0, step = dx, length = length(y)))
+    expsum_fit(x, y, n; kwargs...)
 end
 
 function expsum_scale!(x::AbstractVector{T}, y::AbstractVector{T}) where {T <: Real}
-	sc = (x = maximum(abs, x), y = maximum(abs, y))
-	x ./= sc.x
-	y ./= sc.y
-	return sc
+    sc = (x = maximum(abs, x), y = maximum(abs, y))
+    x ./= sc.x
+    y ./= sc.y
+    return sc
 end
 
 """
-	expsum_init(x::AbstractVector{T}, n::Int; m::Int = 1, withconst::Bool = true) where {T <: Real}
+    expsum_init(x::AbstractVector{T}, n::Int; m::Int = 1, withconst::Bool = true) where {T <: Real}
 
 Initialize most of the memory needed for [`expsum_fit`](@ref).
 """
 function expsum_init(x::AbstractVector{T}, n::Int; m::Int = 1, withconst::Bool = true) where {T <: Real}
-	len = length(x)
-	nY, mY = 1 + (len - 1) ÷ m, 2n + withconst
-	return ExpSumFitInit(n, m, zeros(T, nY, mY), zeros(T, nY, n - 1),
-		zeros(T, mY),
-		diagm(-1 => ones(T, n - 1)), # companion matrix
-		zeros(Complex{T}, len, n + withconst),
-		zeros(T, len, n + withconst),
-		T.(calc_integral_rules(1:n, m = m)))
+    len = length(x)
+    nY, mY = 1 + (len - 1) ÷ m, 2n + withconst
+    return ExpSumFitInit(n, m, zeros(T, nY, mY), zeros(T, nY, n - 1),
+        zeros(T, mY),
+        diagm(-1 => ones(T, n - 1)), # companion matrix
+        zeros(Complex{T}, len, n + withconst),
+        zeros(T, len, n + withconst),
+        T.(calc_integral_rules(1:n, m = m)))
 end
 
 function expfit_solve(init::ExpSumFitInit, x, y, sc::NamedTuple)
-	n, Y, n = init.n, init.Y, init.n
-	expsum_fill_Y!(init, x, y)
-	λ, τ = expfit_solve_λ(init, y)
-	if isreal(λ)
-		X = init.Xr
-	else
-		X = init.Xc
-	end
-	expsum_fill_X!(init, x, λ, X)
-	qrX = qr!(X)
-	p = qrX \ y
-	if isreal(p)
-		p = real(p)
-	end
-	x .*= sc.x
-	y .*= sc.y
-	withconst = size(Y)[2] == 2n + 1
-	if withconst
-		return ExpSumFit(real(p[end]) * sc.y, p[1:n] * sc.y, λ / sc.x, τ * sc.x)
-	else
-		return ExpSumFit(0.0, p * sc.y, λ / sc.x, τ * sc.x)
-	end
+    n, Y, n = init.n, init.Y, init.n
+    expsum_fill_Y!(init, x, y)
+    λ, τ = expfit_solve_λ(init, y)
+    if isreal(λ)
+        X = init.Xr
+    else
+        X = init.Xc
+    end
+    expsum_fill_X!(init, x, λ, X)
+    qrX = qr!(X)
+    p = qrX \ y
+    if isreal(p)
+        p = real(p)
+    end
+    x .*= sc.x
+    y .*= sc.y
+    withconst = size(Y)[2] == 2n + 1
+    if withconst
+        return ExpSumFit(real(p[end]) * sc.y, p[1:n] * sc.y, λ / sc.x, τ * sc.x)
+    else
+        return ExpSumFit(0.0, p * sc.y, λ / sc.x, τ * sc.x)
+    end
 end
 
 """
-	cumints!(init::ExpSumFitInit, x::AbstractVector{T}, y::AbstractVector{T}) where {T <: Real}
+    cumints!(init::ExpSumFitInit, x::AbstractVector{T}, y::AbstractVector{T}) where {T <: Real}
 
 Calculates in-place `init.n` cumulative integrals using coeffients `init.coeff`.
 """
 function cumints!(init::ExpSumFitInit, x::AbstractVector{T}, y::AbstractVector{T}) where {T <: Real}
-	n, m, Y, S, coeff = init.n, init.m, init.Y, init.S, init.coeff
-	n > 0 || error("Number of exponential terms should be a positive integer")
-	m > 0 || error("Order of interpolating polynomial should be a positive integer")
-	len = size(init.Y)[1]
-	S .= 0.0
-	for j = 1:n
-		Y[1,j] = 0.0
-		for i = 2:len
-			dx = x[m*(i-2) + 2] - x[m*(i-2) + 1]
-			s = 0.0
-			for k = 1:m+1
-				s += coeff[j,k] * y[m * (i - 2) + k]
-			end
-			Y[i,j] = Y[i-1,j] + dx^j*s
-		end
-	end
-	for j = 2:n
-		for i = 2:len
-			S[i,j-1] += S[i-1,j-1] + Y[i,j-1] # at this stage Y[:,j-1] is calculated
-		end
-		for k = 1:j-1
-			f = factorial(k)
-			for i = 2:len
-				dx = x[m * (i-2) + 2] - x[m * (i-2) + 1]
-				Y[i,j] += S[i-1,j-k] / f * (m*dx)^k
-			end
-		end
-	end
-	nothing
+    n, m, Y, S, coeff = init.n, init.m, init.Y, init.S, init.coeff
+    n > 0 || error("Number of exponential terms should be a positive integer")
+    m > 0 || error("Order of interpolating polynomial should be a positive integer")
+    len = size(init.Y)[1]
+    S .= 0.0
+    for j = 1:n
+        Y[1,j] = 0.0
+        for i = 2:len
+            dx = x[m*(i-2) + 2] - x[m*(i-2) + 1]
+            s = 0.0
+            for k = 1:m+1
+                s += coeff[j,k] * y[m * (i - 2) + k]
+            end
+            Y[i,j] = Y[i-1,j] + dx^j*s
+        end
+    end
+    for j = 2:n
+        for i = 2:len
+            S[i,j-1] += S[i-1,j-1] + Y[i,j-1] # at this stage Y[:,j-1] is calculated
+        end
+        for k = 1:j-1
+            f = factorial(k)
+            for i = 2:len
+                dx = x[m * (i-2) + 2] - x[m * (i-2) + 1]
+                Y[i,j] += S[i-1,j-k] / f * (m*dx)^k
+            end
+        end
+    end
+    nothing
 end
 
 """
-	calc_integral_rules(n; m = 2)
+    calc_integral_rules(n; m = 2)
 
 Determine coefficients of the rules cumulative integrals of order `n` using
 [method of undetermined coefficients](https://en.wikipedia.org/wiki/Simpson%27s_rule#Undetermined_coefficients).
@@ -153,94 +153,94 @@ Interpolation order is `m`.
 * `n=1`, `m=3` [Simpson's second (3/8) rule](https://en.wikipedia.org/wiki/Simpson%27s_rule#Simpson's_3/8_rule)
 """
 function calc_integral_rules(n::Int; m::Int = 2)
-	n ≥ 1 || throw(ArgumentError("n=$n should be positive integer"))
-	n = big(n)
-	# evaluate m-th order polynomial terms at points x=0:m
-	polyvals = [x^n for x = 0:Rational(m), n = 0:m]
-	# evaluate m-th order polynomial terms integrated cumulatively n-times
-	integralvals = [m^(n+i)*factorial(i) // factorial(n+i) for i=0:m]'
-	coeff = integralvals / polyvals
-	return coeff
+    n ≥ 1 || throw(ArgumentError("n=$n should be positive integer"))
+    n = big(n)
+    # evaluate m-th order polynomial terms at points x=0:m
+    polyvals = [x^n for x = 0:Rational(m), n = 0:m]
+    # evaluate m-th order polynomial terms integrated cumulatively n-times
+    integralvals = [m^(n+i)*factorial(i) // factorial(n+i) for i=0:m]'
+    coeff = integralvals / polyvals
+    return coeff
 end
 
 function calc_integral_rules(ns::Union{UnitRange{Int}, Vector{Int}}; m::Int = 2)
-	reduce(vcat, [calc_integral_rules(n, m = m) for n in ns])
+    reduce(vcat, [calc_integral_rules(n, m = m) for n in ns])
 end
 
 """
-	expsum_fill_Y!(init::ExpSumFitInit, x, y)
+    expsum_fill_Y!(init::ExpSumFitInit, x, y)
 
 Fills matrix `Y` with
 ```math
-	[\\int^1 \\int^2 \\ldots \\int^n x^0 x^1 \\ldots x^{m-n-1}]
+    [\\int^1 \\int^2 \\ldots \\int^n x^0 x^1 \\ldots x^{m-n-1}]
 ```
 where `∫ⁱ` means the ith cumulative integral of `y` vs `x`, and `m` is the
 number of columns in matrix `Y`.
 """
 function expsum_fill_Y!(init::ExpSumFitInit, x::AbstractVector{T}, y::AbstractVector{T}) where {T <: Real}
-	n, m, Y = init.n, init.m, init.Y
-	nY, mY = size(Y)
-	cumints!(init, x, y)
-	for j = 1:mY
-		Y[1,j] = 0.0
-	end
-	for j = 0:mY - n - 1
-		for i = 1:nY
-			Y[i,j + n + 1] = x[m*(i-1) + 1]^j
-		end
-	end
-	nothing
+    n, m, Y = init.n, init.m, init.Y
+    nY, mY = size(Y)
+    cumints!(init, x, y)
+    for j = 1:mY
+        Y[1,j] = 0.0
+    end
+    for j = 0:mY - n - 1
+        for i = 1:nY
+            Y[i,j + n + 1] = x[m*(i-1) + 1]^j
+        end
+    end
+    nothing
 end
 
 """
-	expsum_fill_X!(init::ExpSumFitInit, x, λ, X)
+    expsum_fill_X!(init::ExpSumFitInit, x, λ, X)
 
 Fills matrix `init.X`
 ```math
-	[e^{x\\lambda_1} e^{x\\lambda_2} \\ldots e^{x\\lambda_n}]
+    [e^{x\\lambda_1} e^{x\\lambda_2} \\ldots e^{x\\lambda_n}]
 ```
 or if fitting is done with constant
 ```math
-	[e^{x\\lambda_1} e^{x\\lambda_2} \\ldots e^{x\\lambda_n} 1]
+    [e^{x\\lambda_1} e^{x\\lambda_2} \\ldots e^{x\\lambda_n} 1]
 ```
 """
 function expsum_fill_X!(init::ExpSumFitInit, x::AbstractVector{T}, λ::AbstractVector{S}, X::AbstractMatrix{S}) where {T <: Real, S <: Number}
-	n = init.n
-	nX, mX = size(X)
-	for j = 1:n
-		for i = 1:nX
-			X[i,j] = exp(x[i]*λ[j])
-		end
-	end
-	for j = n+1:mX
-		for i = 1:nX
-			X[i,j] = 1.0
-		end
-	end
-	nothing
+    n = init.n
+    nX, mX = size(X)
+    for j = 1:n
+        for i = 1:nX
+            X[i,j] = exp(x[i]*λ[j])
+        end
+    end
+    for j = n+1:mX
+        for i = 1:nX
+            X[i,j] = 1.0
+        end
+    end
+    nothing
 end
 
 function expfit_solve_λ(init::ExpSumFitInit, y)
-	n, m, Y, A, Ā = init.n, init.m, init.Y, init.A, init.Ā
-	qrY = qr!(Y)
-	A .= qrY \ view(y, 1:m:length(y))
-	Ā[1,1:n] = A[1:n]
-	λ = eigvals(Ā)
-	if isreal(λ)
-		λ = real(λ)
-	end
-	τ = -1 ./ λ
-	return λ, τ
+    n, m, Y, A, Ā = init.n, init.m, init.Y, init.A, init.Ā
+    qrY = qr!(Y)
+    A .= qrY \ view(y, 1:m:length(y))
+    Ā[1,1:n] = A[1:n]
+    λ = eigvals(Ā)
+    if isreal(λ)
+        λ = real(λ)
+    end
+    τ = -1 ./ λ
+    return λ, τ
 end
 
 """
-	(sol::ExpSumFit)(x)
+    (sol::ExpSumFit)(x)
 
 Calculate the sum of exponentials using solution `sol` at points `x`.
 """
 function (f::ExpSumFit)(x)
-	k, p, λ = f.k, f.p, f.λ
-	y = k .+ sum(exp.(x * λ') .* p', dims = 2)
-	y = real.(y[:])
-	return y
+    k, p, λ = f.k, f.p, f.λ
+    y = k .+ sum(exp.(x * λ') .* p', dims = 2)
+    y = real.(y[:])
+    return y
 end


### PR DESCRIPTION
The title of the PR reflects its primary purposes, though I've also made some minor housekeeping updates along with it. Summary of changes made in this PR:
- The badges for Travis, AppVeyor, and Coveralls have been removed from README.md, as CI is run solely on GitHub Actions and coverage is submitted only to Codecov.
- The CI workflow trigger has been simplified to match that in Example.jl. The only functional difference is that this will now run CI for pull requests against branches other than `master`.
- Julia versions 1.0 and 1.5 have been replaced with 1.6 and 1 (current stable 1.x release) in the CI matrix, as the package only supports Julia 1.6 and later.
- The caching step has been replaced with the `julia-actions/cache@v1` action, which provides that functionality.
- The Codecov action has been updated to version 2, as version 1 is unsupported upstream.
- `src/expsumfit.jl` has been amended to normalize line endings to LF and indentation to four spaces, matching the rest of the repository; it was the only file that used tabs for indentation and DOS-style line endings (CRLF). When viewing the changes made in this PR without whitespace sensitivity (Files changed > ⚙️🔽 > Hide whitespace > Apply and reload), there should be no visible changes to this file.